### PR TITLE
Abstract common logic for clients

### DIFF
--- a/client/src/lib/server/grpc.ts
+++ b/client/src/lib/server/grpc.ts
@@ -25,44 +25,37 @@ export const proto = loadPackageDefinition(
     packageDefinition,
 ) as unknown as ProtoGrpcType;
 
-export const usersRustClient = new proto.proto.UsersService(
-    URI_USERS_RUST,
+const getCertificate = () =>
     ENV === "production"
         ? credentials.createSsl()
-        : credentials.createInsecure(),
+        : credentials.createInsecure();
+
+export const usersRustClient = new proto.proto.UsersService(
+    URI_USERS_RUST,
+    getCertificate(),
 );
 
 export const usersGoClient = new proto.proto.UsersService(
     URI_USERS_GO,
-    ENV === "production"
-        ? credentials.createSsl()
-        : credentials.createInsecure(),
+    getCertificate(),
 );
 
 export const utilsRustClient = new proto.proto.UtilsService(
     URI_UTILS_RUST,
-    ENV === "production"
-        ? credentials.createSsl()
-        : credentials.createInsecure(),
+    getCertificate(),
 );
 
 export const utilsGoClient = new proto.proto.UtilsService(
     URI_UTILS_GO,
-    ENV === "production"
-        ? credentials.createSsl()
-        : credentials.createInsecure(),
+    getCertificate(),
 );
 
 export const notesRustClient = new proto.proto.NotesService(
     URI_NOTES_RUST,
-    ENV === "production"
-        ? credentials.createSsl()
-        : credentials.createInsecure(),
+    getCertificate(),
 );
 
 export const notesGoClient = new proto.proto.NotesService(
     URI_NOTES_GO,
-    ENV === "production"
-        ? credentials.createSsl()
-        : credentials.createInsecure(),
+    getCertificate(),
 );

--- a/client/src/lib/server/grpc.ts
+++ b/client/src/lib/server/grpc.ts
@@ -1,5 +1,9 @@
 import protoLoader from "@grpc/proto-loader";
-import { credentials, loadPackageDefinition } from "@grpc/grpc-js";
+import {
+    ChannelCredentials,
+    credentials,
+    loadPackageDefinition,
+} from "@grpc/grpc-js";
 import type { ProtoGrpcType } from "$lib/proto/main";
 import {
     ENV,
@@ -25,37 +29,19 @@ export const proto = loadPackageDefinition(
     packageDefinition,
 ) as unknown as ProtoGrpcType;
 
-const getCertificate = () =>
+const cr: ChannelCredentials =
     ENV === "production"
         ? credentials.createSsl()
         : credentials.createInsecure();
 
-export const usersRustClient = new proto.proto.UsersService(
-    URI_USERS_RUST,
-    getCertificate(),
-);
+export const usersRustClient = new proto.proto.UsersService(URI_USERS_RUST, cr);
 
-export const usersGoClient = new proto.proto.UsersService(
-    URI_USERS_GO,
-    getCertificate(),
-);
+export const usersGoClient = new proto.proto.UsersService(URI_USERS_GO, cr);
 
-export const utilsRustClient = new proto.proto.UtilsService(
-    URI_UTILS_RUST,
-    getCertificate(),
-);
+export const utilsRustClient = new proto.proto.UtilsService(URI_UTILS_RUST, cr);
 
-export const utilsGoClient = new proto.proto.UtilsService(
-    URI_UTILS_GO,
-    getCertificate(),
-);
+export const utilsGoClient = new proto.proto.UtilsService(URI_UTILS_GO, cr);
 
-export const notesRustClient = new proto.proto.NotesService(
-    URI_NOTES_RUST,
-    getCertificate(),
-);
+export const notesRustClient = new proto.proto.NotesService(URI_NOTES_RUST, cr);
 
-export const notesGoClient = new proto.proto.NotesService(
-    URI_NOTES_GO,
-    getCertificate(),
-);
+export const notesGoClient = new proto.proto.NotesService(URI_NOTES_GO, cr);


### PR DESCRIPTION
Abstracting this logic should help keep it maintainable. Since each client should use a unique certificate, this was kept as a function rather than saving one certificate. 